### PR TITLE
Fix broken peer dependency path when symlinked

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,10 @@ module.exports = {
   included() {
     this._super.included.apply(this, arguments);
 
-    this.import(path.resolve(path.dirname(require.resolve('number-to-words')), '../numberToWords.js').substr(process.cwd().length + 1));
+    let peerDependencyPath = path.resolve(path.dirname(require.resolve('number-to-words')), '../numberToWords.js')
+      .match(/\/(node_modules\/.+)/)[1];
+
+    this.import(peerDependencyPath);
     this.import('vendor/shims/number-to-words.js');
   }
 };


### PR DESCRIPTION
When symlinking this addon, an invalid path is generated for the peer dependency.

**To reproduce**
1. Run `ember install ember-number-to-words-shim` in `<my-ember-app>`
2. Clone ember-number-to-words-shim and run `npm link`
3. In `<my-ember-app>` run `npm link ember-number-to-words-shim && ember s`

The build should fail with this path in the error message:
`o-words-shim/node_modules/number-to-words/numberToWords.js`.

The correct path should be:
`node_modules/number-to-words/numberToWords.js`

Both `npm link` and `yarn link` produce same behaviour in this case.